### PR TITLE
Add tests for sync utilities

### DIFF
--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from analyze.analyzer import strip_prefix, try_match
+
+
+def test_strip_prefix():
+    assert strip_prefix("〔非表示〕[Circle] Title") == "[Circle] Title"
+    assert strip_prefix("NoPrefix") == "NoPrefix"
+
+
+def test_try_match_with_author():
+    name = "｛CG集｝[サークル (作者)] タイトル (ソース)"
+    result = try_match(name)
+    assert result == {
+        "type": "CG集",
+        "circle": "サークル",
+        "author": "作者",
+        "title": "タイトル",
+        "source": "ソース",
+    }
+
+
+def test_try_match_no_author():
+    name = "｛漫画｝[サークル] タイトル (ジャンプ)"
+    result = try_match(name)
+    assert result == {
+        "type": "漫画",
+        "circle": "サークル",
+        "title": "タイトル",
+        "source": "ジャンプ",
+    }
+
+
+def test_try_match_circle_title():
+    name = "[サークル] タイトル1"
+    result = try_match(name)
+    assert result == {
+        "circle": "サークル",
+        "title": "タイトル",
+    }
+
+
+def test_try_match_none():
+    assert try_match("random text") == {"title": "random text"}

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,0 +1,53 @@
+import os
+import sys
+import json
+import csv
+from datetime import datetime
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import folders.classifier as classifier
+
+
+class FixedDatetime:
+    @classmethod
+    def now(cls):
+        return datetime(2022, 1, 2, 3, 4)
+
+
+def test_classify_and_export(tmp_path, monkeypatch):
+    base = tmp_path / "base"
+    base.mkdir()
+    cat = base / "【画像10枚以上】"
+    cat.mkdir()
+    f1 = cat / "A"
+    f1.mkdir()
+    (f1 / "x.jpg").write_bytes(b"")
+    (f1 / "other.txt").write_bytes(b"")
+    f2 = cat / "B"
+    f2.mkdir()
+    (f2 / "y.png").write_bytes(b"")
+
+    monkeypatch.setattr(classifier, "BASE_DIRS", [str(base)])
+    monkeypatch.setattr(classifier, "CLASSIFY_OUTPUT_PREFIX", "pref")
+    monkeypatch.setattr(classifier, "THRESHOLD", 5)
+    monkeypatch.setattr(classifier, "datetime", FixedDatetime)
+
+    classifier.classify_and_export()
+
+    stem = "pref_thresh5_20220102-0304"
+    json_path = base / f"{stem}.json"
+    csv_path = base / f"{stem}.csv"
+    assert json_path.is_file()
+    assert csv_path.is_file()
+
+    data = json.loads(json_path.read_text(encoding="utf-8"))
+    assert len(data) == 2
+    names = sorted([rec["original_name"] for rec in data])
+    assert names == ["A", "B"]
+
+    with open(csv_path, encoding="utf-8-sig") as f:
+        rows = list(csv.DictReader(f))
+    csv_names = sorted(row["original_name"] for row in rows)
+    assert csv_names == names

--- a/tests/test_cleaner.py
+++ b/tests/test_cleaner.py
@@ -1,0 +1,167 @@
+import os
+import sys
+import sqlite3
+from pathlib import Path
+from contextlib import contextmanager
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import sync.cleaner as cleaner
+
+
+def setup_db(path: Path):
+    with open(Path(__file__).resolve().parents[1] / "db" / "schema.sql", "r") as f:
+        schema = f.read()
+    conn = sqlite3.connect(path)
+    conn.executescript(schema)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def patch_get_connection(monkeypatch, path: Path):
+    @contextmanager
+    def _connect():
+        conn = sqlite3.connect(path)
+        conn.row_factory = sqlite3.Row
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    monkeypatch.setattr(cleaner, "get_connection", _connect)
+
+
+def test_delete_works_with_missing_folders(tmp_path, monkeypatch):
+    db_path = tmp_path / "db.sqlite"
+    conn = setup_db(db_path)
+    existing = tmp_path / "exist"
+    existing.mkdir()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO works (id, folder_path, original_name, image_count, status)"
+        " VALUES (1, ?, 'n1', 1, 'pending')",
+        (str(existing),),
+    )
+    cur.execute(
+        "INSERT INTO works (id, folder_path, original_name, image_count, status)"
+        " VALUES (2, ?, 'n2', 1, 'pending')",
+        (str(tmp_path / "missing"),),
+    )
+    conn.commit()
+    conn.close()
+
+    patch_get_connection(monkeypatch, db_path)
+    cleaner.delete_works_with_missing_folders()
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    ids = [row["id"] for row in conn.execute("SELECT id FROM works ORDER BY id").fetchall()]
+    conn.close()
+    assert ids == [1]
+
+
+def test_get_all_db_folder_paths(tmp_path, monkeypatch):
+    db_path = tmp_path / "db.sqlite"
+    conn = setup_db(db_path)
+    p1 = tmp_path / "p1"
+    p2 = tmp_path / "p2"
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO works (id, folder_path, original_name, image_count, status)"
+        " VALUES (1, ?, 'n1', 1, 'pending')",
+        (str(p1),),
+    )
+    cur.execute(
+        "INSERT INTO works (id, folder_path, original_name, image_count, status)"
+        " VALUES (2, ?, 'n2', 1, 'pending')",
+        (str(p2),),
+    )
+    conn.commit()
+    conn.close()
+
+    patch_get_connection(monkeypatch, db_path)
+    result = cleaner.get_all_db_folder_paths()
+    expected = {str(p1.resolve()), str(p2.resolve())}
+    assert result == expected
+
+
+def test_delete_physical_folders_not_in_db(tmp_path, monkeypatch):
+    base = tmp_path / "base"
+    base.mkdir()
+    keep = base / "keep"
+    keep.mkdir()
+    remove = base / "remove"
+    remove.mkdir()
+
+    monkeypatch.setattr(cleaner, "BASE_DIRS", [str(base)])
+    monkeypatch.setattr(cleaner, "get_all_db_folder_paths", lambda: {str(keep.resolve())})
+
+    cleaner.delete_physical_folders_not_in_db(dry_run=False)
+
+    assert keep.exists()
+    assert not remove.exists()
+
+
+def test_delete_folders_with_zero_images(tmp_path, monkeypatch):
+    base = tmp_path / "base"
+    base.mkdir()
+    empty = base / "empty"
+    empty.mkdir()
+    filled = base / "filled"
+    filled.mkdir()
+    (filled / "img.jpg").write_bytes(b"x")
+
+    monkeypatch.setattr(cleaner, "BASE_DIRS", [str(base)])
+
+    cleaner.delete_folders_with_zero_images(dry_run=False)
+
+    assert filled.exists()
+    assert not empty.exists()
+
+
+def test_delete_orphan_relations(tmp_path, monkeypatch):
+    db_path = tmp_path / "db.sqlite"
+    conn = setup_db(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO works (id, folder_path, original_name, image_count, status)"
+        " VALUES (1, 'p', 'o', 1, 'pending')"
+    )
+    cur.execute(
+        "INSERT INTO work_circle_authors (work_id, circle_id, author_id) VALUES (1,1,NULL)"
+    )
+    cur.execute(
+        "INSERT INTO work_sources (work_id, source_id) VALUES (1,1)"
+    )
+    cur.execute(
+        "INSERT INTO work_completion_state (work_id) VALUES (1)"
+    )
+    # orphan entries for work_id = 2
+    cur.execute(
+        "INSERT INTO work_circle_authors (work_id, circle_id, author_id) VALUES (2,1,NULL)"
+    )
+    cur.execute(
+        "INSERT INTO work_sources (work_id, source_id) VALUES (2,1)"
+    )
+    cur.execute(
+        "INSERT INTO work_completion_state (work_id) VALUES (2)"
+    )
+    conn.commit()
+    conn.close()
+
+    patch_get_connection(monkeypatch, db_path)
+    cleaner.delete_orphan_relations()
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) AS cnt FROM work_circle_authors WHERE work_id = 2")
+    assert cur.fetchone()["cnt"] == 0
+    cur.execute("SELECT COUNT(*) AS cnt FROM work_sources WHERE work_id = 2")
+    assert cur.fetchone()["cnt"] == 0
+    cur.execute("SELECT COUNT(*) AS cnt FROM work_completion_state WHERE work_id = 2")
+    assert cur.fetchone()["cnt"] == 0
+    # valid rows remain
+    cur.execute("SELECT COUNT(*) AS cnt FROM work_circle_authors WHERE work_id = 1")
+    assert cur.fetchone()["cnt"] == 1
+    conn.close()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,116 @@
+import os
+import sys
+import sqlite3
+from pathlib import Path
+from contextlib import contextmanager
+import json
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import db.handler as handler
+import db.loader as loader
+
+
+def setup_db(path: Path):
+    with open(Path(__file__).resolve().parents[1] / "db" / "schema.sql", "r") as f:
+        schema = f.read()
+    conn = sqlite3.connect(path)
+    conn.executescript(schema)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def patch_get_connection(monkeypatch, path: Path):
+    @contextmanager
+    def _connect():
+        conn = sqlite3.connect(path)
+        conn.row_factory = sqlite3.Row
+        try:
+            yield conn
+        finally:
+            conn.close()
+    monkeypatch.setattr(handler, "get_connection", _connect)
+
+
+# --- handler.get_connection ---
+def test_get_connection_closes(tmp_path):
+    db_path = tmp_path / "db.sqlite"
+    with handler.get_connection(db_path) as conn:
+        assert conn.row_factory == sqlite3.Row
+        conn.execute("CREATE TABLE sample(id INTEGER)")
+    with pytest.raises(sqlite3.ProgrammingError):
+        conn.execute("SELECT 1")
+
+
+# --- insert_work, work_exists, get_all_works ---
+def test_basic_work_functions(tmp_path, monkeypatch):
+    db_path = tmp_path / "works.sqlite"
+    setup_db(db_path).close()
+    patch_get_connection(monkeypatch, db_path)
+
+    assert handler.get_all_works() == []
+
+    handler.insert_work("p1", "Name", 3)
+    assert handler.work_exists("p1")
+    assert not handler.work_exists("p2")
+
+    rows = handler.get_all_works()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["folder_path"] == "p1"
+    assert row["original_name"] == "Name"
+    assert row["image_count"] == 3
+
+
+# --- loader helpers ---
+def test_find_latest_json(tmp_path):
+    base = tmp_path
+    old = base / f"{loader.CLASSIFY_OUTPUT_PREFIX}_old.json"
+    new = base / f"{loader.CLASSIFY_OUTPUT_PREFIX}_new.json"
+    old.write_text("[]", encoding="utf-8")
+    new.write_text("[]", encoding="utf-8")
+    os.utime(old, (1, 1))
+    os.utime(new, None)
+
+    result = loader.find_latest_json(base)
+    assert result == new
+
+    (base / "nomatch.json").write_text("{}", encoding="utf-8")
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    assert loader.find_latest_json(empty_dir) is None
+
+
+def test_load_classified_works(tmp_path, monkeypatch):
+    db_path = tmp_path / "loader.sqlite"
+    setup_db(db_path).close()
+    patch_get_connection(monkeypatch, db_path)
+    monkeypatch.setattr(loader, "BASE_DIRS", [str(tmp_path)])
+
+    records = [
+        {"folder_path": "p1", "original_name": "N1", "image_count": 5},
+        {"folder_path": "p2", "original_name": "N2", "image_count": 7},
+    ]
+    json_path = tmp_path / f"{loader.CLASSIFY_OUTPUT_PREFIX}_test.json"
+    json_path.write_text(json.dumps(records), encoding="utf-8")
+
+    # Pre-insert p1 to test skipping
+    conn = sqlite3.connect(db_path)
+    conn.execute("INSERT INTO works (folder_path, original_name, image_count, status) VALUES ('p1', 'exist', 1, 'pending')")
+    conn.commit()
+    conn.close()
+
+    loader.load_classified_works()
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute("SELECT folder_path, original_name, image_count FROM works ORDER BY folder_path").fetchall()
+    conn.close()
+
+    assert len(rows) == 2
+    assert rows[0]["folder_path"] == "p1"  # existing preserved
+    assert rows[0]["original_name"] == "exist"
+    assert rows[1]["folder_path"] == "p2"
+    assert rows[1]["original_name"] == "N2"
+    assert rows[1]["image_count"] == 7

--- a/tests/test_image_counter.py
+++ b/tests/test_image_counter.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from utils.image_counter import count_images
+
+
+def test_count_images(tmp_path):
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "a.jpg").write_bytes(b"")
+    (tmp_path / "b.txt").write_bytes(b"")
+    (tmp_path / "sub" / "c.png").write_bytes(b"")
+    assert count_images(tmp_path) == 2
+
+
+def test_count_images_nonexistent(tmp_path):
+    nonexistent = tmp_path / "nonexistent"
+    assert count_images(nonexistent) == 0

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -3,7 +3,11 @@ import sys
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from utils.normalizer import normalize_for_filename
+from utils.normalizer import (
+    normalize_for_filename,
+    normalize_text,
+    normalize_for_matching,
+)
 
 @pytest.mark.parametrize('original,expected', [
     ('hoge/fuga', 'hoge／fuga'),
@@ -12,3 +16,25 @@ from utils.normalizer import normalize_for_filename
 ])
 def test_normalize_for_filename(original, expected):
     assert normalize_for_filename(original) == expected
+
+
+@pytest.mark.parametrize(
+    'original,expected',
+    [
+        ('ＡＢＣ　ｄｅｆ', 'ABC def'),
+        ('foo  bar\tbaz', 'foo bar baz'),
+    ],
+)
+def test_normalize_text(original, expected):
+    assert normalize_text(original) == expected
+
+
+@pytest.mark.parametrize(
+    'original,expected',
+    [
+        ('ＦｏｏーＢａｒ！', 'fooーbar'),
+        (' ばなな★ ', 'ばなな'),
+    ],
+)
+def test_normalize_for_matching(original, expected):
+    assert normalize_for_matching(original) == expected

--- a/tests/test_reconciler.py
+++ b/tests/test_reconciler.py
@@ -1,0 +1,99 @@
+import os
+import sys
+import sqlite3
+from pathlib import Path
+from contextlib import contextmanager
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import sync.reconciler as reconciler
+
+
+def setup_db(path: Path):
+    with open(Path(__file__).resolve().parents[1] / "db" / "schema.sql", "r") as f:
+        schema = f.read()
+    conn = sqlite3.connect(path)
+    conn.executescript(schema)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def patch_get_connection(monkeypatch, path: Path):
+    @contextmanager
+    def _connect():
+        conn = sqlite3.connect(path)
+        conn.row_factory = sqlite3.Row
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    monkeypatch.setattr(reconciler, "get_connection", _connect)
+
+
+def test_get_all_db_paths(tmp_path, monkeypatch):
+    db_path = tmp_path / "db.sqlite"
+    conn = setup_db(db_path)
+    cur = conn.cursor()
+    p1 = tmp_path / "p1"
+    p2 = tmp_path / "p2"
+    cur.execute(
+        "INSERT INTO works (id, folder_path, original_name, image_count, status)"
+        " VALUES (1, ?, 'orig1', 1, 'pending')",
+        (str(p1),),
+    )
+    cur.execute(
+        "INSERT INTO works (id, folder_path, original_name, image_count, status)"
+        " VALUES (2, ?, 'orig2', 2, 'pending')",
+        (str(p2),),
+    )
+    conn.commit()
+    conn.close()
+
+    patch_get_connection(monkeypatch, db_path)
+
+    result = reconciler.get_all_db_paths()
+    expected = {
+        str(p1.resolve()): (1, "orig1"),
+        str(p2.resolve()): (2, "orig2"),
+    }
+    assert result == expected
+
+
+def test_get_all_physical_folders(tmp_path, monkeypatch):
+    base = tmp_path / "base"
+    base.mkdir()
+    f1 = base / "A"
+    f1.mkdir()
+    f2 = base / "B"
+    f2.mkdir()
+    (base / "notdir.txt").write_text("x", encoding="utf-8")
+
+    monkeypatch.setattr(reconciler, "BASE_DIRS", [str(base)])
+
+    result = reconciler.get_all_physical_folders()
+    assert set(result) == {f1.resolve(), f2.resolve()}
+
+
+def test_compare_db_and_folders(capsys, tmp_path, monkeypatch):
+    p1 = (tmp_path / "p1").resolve()
+    p2 = (tmp_path / "p2").resolve()
+    p3 = (tmp_path / "p3").resolve()
+
+    monkeypatch.setattr(
+        reconciler,
+        "get_all_db_paths",
+        lambda: {str(p1): (1, "O1"), str(p2): (2, "O2")},
+    )
+    monkeypatch.setattr(
+        reconciler,
+        "get_all_physical_folders",
+        lambda: [p2, p3],
+    )
+
+    reconciler.compare_db_and_folders()
+    out = capsys.readouterr().out
+    assert "DB登録：2 件" in out
+    assert "実フォルダ：2 件" in out
+    assert "❌ 実体が存在しない（DBにだけある）：1 件" in out
+    assert "➕ 未登録（物理にだけある）：1 件" in out

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -1,0 +1,128 @@
+import os
+import sys
+import sqlite3
+from pathlib import Path
+from contextlib import contextmanager
+from datetime import datetime
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import folders.rename as rename
+from utils.normalizer import normalize_for_filename
+
+
+def setup_db(path: Path):
+    with open(Path(__file__).resolve().parents[1] / "db" / "schema.sql", "r") as f:
+        schema = f.read()
+    conn = sqlite3.connect(path)
+    conn.executescript(schema)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def patch_get_connection(monkeypatch, path: Path):
+    @contextmanager
+    def _connect():
+        conn = sqlite3.connect(path)
+        conn.row_factory = sqlite3.Row
+        try:
+            yield conn
+        finally:
+            conn.close()
+    monkeypatch.setattr(rename, "get_connection", _connect)
+
+
+def test_compose_folder_name(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.sqlite"
+    conn = setup_db(db_path)
+    cur = conn.cursor()
+    cur.execute("INSERT INTO types (id,name) VALUES (1,'CG集')")
+    cur.execute("INSERT INTO circles (id,name) VALUES (1,'C1'),(2,'C2')")
+    cur.execute("INSERT INTO authors (id,name) VALUES (1,'A1')")
+    cur.execute("INSERT INTO sources (id,name) VALUES (1,'S1'),(2,'S2')")
+    cur.execute(
+        "INSERT INTO works (id, folder_path, original_name, image_count, status, type_id, title)"
+        " VALUES (1, 'p', 'orig', 0, 'pending', 1, 'Title')"
+    )
+    cur.execute("INSERT INTO work_circle_authors (work_id,circle_id,author_id) VALUES (1,1,1)")
+    cur.execute("INSERT INTO work_circle_authors (work_id,circle_id,author_id) VALUES (1,2,NULL)")
+    cur.execute("INSERT INTO work_sources (work_id,source_id) VALUES (1,1)")
+    cur.execute("INSERT INTO work_sources (work_id,source_id) VALUES (1,2)")
+    conn.commit()
+    conn.close()
+
+    patch_get_connection(monkeypatch, db_path)
+
+    result = rename.compose_folder_name(1)
+    expected = normalize_for_filename('｛CG集｝[C1 (A1)、C2] Title （S1、S2）')
+    assert result == expected
+
+
+def test_rename_one_work(tmp_path, monkeypatch):
+    db_path = tmp_path / "db.sqlite"
+    conn = setup_db(db_path)
+    old_dir = tmp_path / "old"
+    old_dir.mkdir()
+    conn.execute(
+        "INSERT INTO works (id, folder_path, original_name, image_count, status, title)"
+        " VALUES (1, ?, 'orig', 1, 'pending', 'T1')",
+        (str(old_dir),),
+    )
+    conn.commit()
+    conn.close()
+
+    patch_get_connection(monkeypatch, db_path)
+    monkeypatch.setattr(rename, "compose_folder_name", lambda _id: "new")
+
+    assert rename.rename_one_work(1)
+    new_path = tmp_path / "new"
+    assert new_path.exists()
+    assert not old_dir.exists()
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute("SELECT folder_path, status FROM works WHERE id = 1").fetchone()
+    conn.close()
+    assert row["folder_path"] == str(new_path)
+    assert row["status"] == "renamed"
+
+
+def test_rename_all_confirmed_works(tmp_path, monkeypatch):
+    db_path = tmp_path / "db.sqlite"
+    conn = setup_db(db_path)
+    old_dir = tmp_path / "old"
+    old_dir.mkdir()
+    conn.execute(
+        "INSERT INTO works (id, folder_path, original_name, image_count, status, title)"
+        " VALUES (1, ?, 'orig', 1, 'confirmed', 'T')",
+        (str(old_dir),),
+    )
+    conn.execute(
+        "INSERT INTO work_completion_state (work_id,circle_id_done,author_id_done,source_id_done,type_id_done,title_done)"
+        " VALUES (1,1,1,1,1,1)"
+    )
+    conn.commit()
+    conn.close()
+
+    patch_get_connection(monkeypatch, db_path)
+    monkeypatch.setattr(rename, "compose_folder_name", lambda _id: "new")
+    class DummyDatetime:
+        @classmethod
+        def now(cls):
+            return datetime(2022, 1, 2)
+    monkeypatch.setattr(rename, "datetime", DummyDatetime)
+    monkeypatch.chdir(tmp_path)
+
+    rename.rename_all_confirmed_works()
+
+    new_path = tmp_path / "new"
+    assert new_path.exists()
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute("SELECT folder_path, status FROM works WHERE id = 1").fetchone()
+    conn.close()
+    assert row["folder_path"] == str(new_path)
+    assert row["status"] == "renamed"
+
+    log_path = tmp_path / "data" / "logs" / "rename_20220102.csv"
+    assert log_path.is_file()

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -1,0 +1,127 @@
+import os
+import sys
+import sqlite3
+from pathlib import Path
+from contextlib import contextmanager
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import analyze.analyzer as analyzer
+import analyze.reviewer as reviewer
+from analyze.analyzer import parse_original_names
+from analyze.reviewer import get_or_create_id, apply_draft_to_works
+import db.handler as handler
+
+
+def setup_db(path: Path):
+    with open(Path(__file__).resolve().parents[1] / "db" / "schema.sql", "r") as f:
+        schema = f.read()
+    conn = sqlite3.connect(path)
+    conn.executescript(schema)
+    conn.execute("ALTER TABLE works ADD COLUMN circle_id INTEGER")
+    conn.execute("ALTER TABLE works ADD COLUMN author_id INTEGER")
+    conn.execute("ALTER TABLE works ADD COLUMN source_id INTEGER")
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def patch_get_connection(monkeypatch, path: Path):
+    @contextmanager
+    def _connect():
+        conn = sqlite3.connect(path)
+        conn.row_factory = sqlite3.Row
+        try:
+            yield conn
+        finally:
+            conn.close()
+    monkeypatch.setattr(analyzer, "get_connection", _connect)
+    monkeypatch.setattr(reviewer, "get_connection", _connect)
+
+
+def test_get_or_create_id_existing():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE circles (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL UNIQUE)")
+    cur.execute("INSERT INTO circles (name) VALUES ('FooBar')")
+    existing_id = cur.lastrowid
+    conn.commit()
+
+    result = get_or_create_id(cur, "circles", "foo bar")
+    assert result == existing_id
+    cur.execute("SELECT COUNT(*) AS cnt FROM circles")
+    assert cur.fetchone()["cnt"] == 1
+    conn.close()
+
+
+def test_get_or_create_id_new():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE circles (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL UNIQUE)")
+    conn.commit()
+
+    result = get_or_create_id(cur, "circles", "B/L?o*g")
+    cur.execute("SELECT name FROM circles WHERE id = ?", (result,))
+    name = cur.fetchone()["name"]
+    assert name == "B／L？o＊g"
+    conn.close()
+
+
+def test_parse_original_names(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.sqlite"
+    monkeypatch.setattr(handler, "DB_PATH", db_path)
+    patch_get_connection(monkeypatch, db_path)
+    conn = setup_db(db_path)
+    cur = conn.cursor()
+    cur.execute("INSERT INTO works (id, folder_path, original_name, image_count, status) VALUES (1, 'p1', '｛CG集｝[C1] T1 (S1)', 10, 'pending')")
+    cur.execute("INSERT INTO works (id, folder_path, original_name, image_count, status) VALUES (2, 'p2', 'random text', 5, 'pending')")
+    conn.commit()
+    conn.close()
+
+    parse_original_names()
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM works_draft ORDER BY work_id")
+    rows = cur.fetchall()
+    assert len(rows) == 2
+    row1 = rows[0]
+    assert row1["circle_raw"] == "C1"
+    assert row1["title_raw"] == "T1"
+    assert row1["source_raw"] == "S1"
+    row2 = rows[1]
+    assert row2["title_raw"] == "random text"
+    conn.close()
+
+
+def test_apply_draft_to_works(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.sqlite"
+    monkeypatch.setattr(handler, "DB_PATH", db_path)
+    patch_get_connection(monkeypatch, db_path)
+    conn = setup_db(db_path)
+    cur = conn.cursor()
+    cur.execute("INSERT INTO works (id, folder_path, original_name, image_count, status) VALUES (1, 'p1', 'name', 10, 'pending')")
+    cur.execute("INSERT INTO works_draft (work_id, circle_raw, author_raw, source_raw, type_raw, title_raw) VALUES (1, 'Circle', 'Author', 'Magazine', 'TypeA', 'Title1')")
+    conn.commit()
+    conn.close()
+
+    apply_draft_to_works()
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+    work = cur.execute("SELECT * FROM works WHERE id = 1").fetchone()
+    assert work["title"] == "Title1"
+    assert work["circle_id"] == 1
+    assert work["author_id"] == 1
+    assert work["source_id"] == 1
+    assert work["type_id"] == 1
+    state = cur.execute("SELECT * FROM work_completion_state WHERE work_id = 1").fetchone()
+    assert state["circle_id_done"] == 1
+    assert state["author_id_done"] == 1
+    assert state["source_id_done"] == 1
+    assert state["type_id_done"] == 1
+    conn.close()


### PR DESCRIPTION
## Summary
- add cleaner tests verifying deletion of missing works and zero-image folders
- add reconciler tests to check path gathering and diff output
- fix CSV order assertion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687242c7b50c832c9d9c1b2eeacc578c