### PR TITLE
Increase rename module test coverage

### DIFF
--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import sqlite3
+import csv
 from pathlib import Path
 from contextlib import contextmanager
 from datetime import datetime
@@ -126,3 +127,143 @@ def test_rename_all_confirmed_works(tmp_path, monkeypatch):
 
     log_path = tmp_path / "data" / "logs" / "rename_20220102.csv"
     assert log_path.is_file()
+# Additional tests for edge cases
+
+import pytest
+
+
+def test_compose_folder_name_missing(tmp_path, monkeypatch):
+    db_path = tmp_path / "db.sqlite"
+    setup_db(db_path).close()
+    patch_get_connection(monkeypatch, db_path)
+    with pytest.raises(ValueError):
+        rename.compose_folder_name(99)
+
+
+def test_rename_one_work_missing_id(tmp_path, monkeypatch, capsys):
+    db_path = tmp_path / "db.sqlite"
+    setup_db(db_path).close()
+    patch_get_connection(monkeypatch, db_path)
+    assert not rename.rename_one_work(1)
+    captured = capsys.readouterr()
+    assert "work_id=1" in captured.out
+
+
+def test_rename_one_work_missing_old_path(tmp_path, monkeypatch, capsys):
+    db_path = tmp_path / "db.sqlite"
+    conn = setup_db(db_path)
+    path = tmp_path / "missing"
+    conn.execute(
+        "INSERT INTO works (id, folder_path, original_name, image_count, status, title)"
+        " VALUES (1, ?, 'o', 0, 'pending', 'T')",
+        (str(path),),
+    )
+    conn.commit()
+    conn.close()
+    patch_get_connection(monkeypatch, db_path)
+    monkeypatch.setattr(rename, "compose_folder_name", lambda _id: "new")
+    assert not rename.rename_one_work(1)
+    captured = capsys.readouterr()
+    assert "存在しません" in captured.out
+
+
+def test_rename_one_work_new_path_exists(tmp_path, monkeypatch, capsys):
+    db_path = tmp_path / "db.sqlite"
+    conn = setup_db(db_path)
+    old_dir = tmp_path / "old"
+    new_dir = tmp_path / "new"
+    old_dir.mkdir()
+    new_dir.mkdir()
+    conn.execute(
+        "INSERT INTO works (id, folder_path, original_name, image_count, status, title)"
+        " VALUES (1, ?, 'o', 0, 'pending', 'T')",
+        (str(old_dir),),
+    )
+    conn.commit()
+    conn.close()
+    patch_get_connection(monkeypatch, db_path)
+    monkeypatch.setattr(rename, "compose_folder_name", lambda _id: "new")
+    assert not rename.rename_one_work(1)
+    captured = capsys.readouterr()
+    assert "既に存在" in captured.out
+    assert old_dir.exists()
+
+
+def prepare_confirmed(db_path: Path, folder: Path) -> None:
+    conn = setup_db(db_path)
+    conn.execute(
+        "INSERT INTO works (id, folder_path, original_name, image_count, status, title)"
+        " VALUES (1, ?, 'o', 0, 'confirmed', 'T')",
+        (str(folder),),
+    )
+    conn.execute(
+        "INSERT INTO work_completion_state (work_id,circle_id_done,author_id_done,source_id_done,type_id_done,title_done)"
+        " VALUES (1,1,1,1,1,1)"
+    )
+    conn.commit()
+    conn.close()
+
+
+def run_confirmed(monkeypatch, db_path: Path, date: datetime, tmp_path: Path):
+    patch_get_connection(monkeypatch, db_path)
+    monkeypatch.setattr(rename, "compose_folder_name", lambda _id: "new")
+    class DummyDatetime:
+        @classmethod
+        def now(cls):
+            return date
+    monkeypatch.setattr(rename, "datetime", DummyDatetime)
+    monkeypatch.chdir(tmp_path)
+    rename.rename_all_confirmed_works()
+
+
+def read_log(tmp_path: Path, date: datetime) -> list:
+    log_path = tmp_path / "data" / "logs" / f"rename_{date:%Y%m%d}.csv"
+    with open(log_path, encoding="utf-8-sig") as f:
+        return list(csv.reader(f))[1:]
+
+
+def test_rename_all_confirmed_missing_old(tmp_path, monkeypatch):
+    db = tmp_path / "db.sqlite"
+    folder = tmp_path / "old"
+    folder.mkdir()
+    prepare_confirmed(db, folder)
+    # remove folder before running
+    os.rmdir(folder)
+    run_confirmed(monkeypatch, db, datetime(2022, 1, 3), tmp_path)
+    logs = read_log(tmp_path, datetime(2022, 1, 3))
+    assert logs[0][3] == "error"
+    assert "missing" in logs[0][4]
+
+
+def test_rename_all_confirmed_new_exists(tmp_path, monkeypatch):
+    db = tmp_path / "db.sqlite"
+    old_dir = tmp_path / "old"
+    new_dir = tmp_path / "new"
+    old_dir.mkdir()
+    new_dir.mkdir()
+    prepare_confirmed(db, old_dir)
+    run_confirmed(monkeypatch, db, datetime(2022, 1, 4), tmp_path)
+    logs = read_log(tmp_path, datetime(2022, 1, 4))
+    assert logs[0][3] == "skipped"
+
+
+def test_rename_all_confirmed_exception(tmp_path, monkeypatch):
+    db = tmp_path / "db.sqlite"
+    folder = tmp_path / "old"
+    folder.mkdir()
+    prepare_confirmed(db, folder)
+    patch_get_connection(monkeypatch, db)
+    monkeypatch.setattr(rename, "compose_folder_name", lambda _id: "new")
+    def fail(*args, **kwargs):
+        raise RuntimeError("boom")
+    monkeypatch.setattr(os, "rename", fail)
+    class DummyDatetime:
+        @classmethod
+        def now(cls):
+            return datetime(2022, 1, 5)
+    monkeypatch.setattr(rename, "datetime", DummyDatetime)
+    monkeypatch.chdir(tmp_path)
+    rename.rename_all_confirmed_works()
+    logs = read_log(tmp_path, datetime(2022, 1, 5))
+    assert logs[0][3] == "error"
+    assert "boom" in logs[0][4]


### PR DESCRIPTION
## Summary
- add missing branch tests for `folders.rename`
- cover error paths for missing IDs, missing folders, pre-existing targets and exceptions

## Testing
- `pytest -q`
- `pytest --cov=folders --cov-report=term-missing tests/test_rename.py -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68728cfffa44832ca1a76732d1670416