### PR TITLE
Append work ID suffix in folder names

### DIFF
--- a/analyze/analyzer.py
+++ b/analyze/analyzer.py
@@ -13,6 +13,11 @@ def strip_prefix(name: str) -> str:
     return re.sub(r"^〔.+?〕", "", name)
 
 
+def strip_suffix_id(name: str) -> str:
+    "suffix '#id123' を除去する"
+    return re.sub(r"\s*#id\d+$", "", name)
+
+
 # 最初にマッチしたパターンを適用
 def try_match(name: str) -> dict | None:
     "🍣"
@@ -39,6 +44,7 @@ def parse_original_names():
         for row in rows:
             work_id = row["id"]
             name = strip_prefix(row["original_name"])
+            name = strip_suffix_id(name)
 
             parsed = try_match(name)
             if not parsed:

--- a/folders/rename.py
+++ b/folders/rename.py
@@ -77,7 +77,11 @@ def compose_folder_name(work_id: int) -> str:
     source_section = f"（{'、'.join(sources)}）" if sources else ""
 
     # 3. 全体構成
-    raw_name = f"｛{type_name}｝[{circle_section}] {title} {source_section}".strip()
+    parts = [f"｛{type_name}｝[{circle_section}]", title]
+    if source_section:
+        parts.append(source_section)
+    parts.append(f"#id{work_id}")
+    raw_name = " ".join(parts)
     return normalize_for_filename(raw_name)
 
 

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -55,7 +55,7 @@ def test_compose_folder_name(tmp_path, monkeypatch):
     patch_get_connection(monkeypatch, db_path)
 
     result = rename.compose_folder_name(1)
-    expected = normalize_for_filename('｛CG集｝[C1 (A1)、C2] Title （S1、S2）')
+    expected = normalize_for_filename('｛CG集｝[C1 (A1)、C2] Title （S1、S2） #id1')
     assert result == expected
 
 
@@ -73,10 +73,10 @@ def test_rename_one_work(tmp_path, monkeypatch):
     conn.close()
 
     patch_get_connection(monkeypatch, db_path)
-    monkeypatch.setattr(rename, "compose_folder_name", lambda _id: "new")
+    monkeypatch.setattr(rename, "compose_folder_name", lambda _id: "new #id1")
 
     assert rename.rename_one_work(1)
-    new_path = tmp_path / "new"
+    new_path = tmp_path / "new #id1"
     assert new_path.exists()
     assert not old_dir.exists()
 
@@ -106,7 +106,7 @@ def test_rename_all_confirmed_works(tmp_path, monkeypatch):
     conn.close()
 
     patch_get_connection(monkeypatch, db_path)
-    monkeypatch.setattr(rename, "compose_folder_name", lambda _id: "new")
+    monkeypatch.setattr(rename, "compose_folder_name", lambda _id: "new #id1")
     class DummyDatetime:
         @classmethod
         def now(cls):
@@ -116,7 +116,7 @@ def test_rename_all_confirmed_works(tmp_path, monkeypatch):
 
     rename.rename_all_confirmed_works()
 
-    new_path = tmp_path / "new"
+    new_path = tmp_path / "new #id1"
     assert new_path.exists()
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
@@ -161,7 +161,7 @@ def test_rename_one_work_missing_old_path(tmp_path, monkeypatch, capsys):
     conn.commit()
     conn.close()
     patch_get_connection(monkeypatch, db_path)
-    monkeypatch.setattr(rename, "compose_folder_name", lambda _id: "new")
+    monkeypatch.setattr(rename, "compose_folder_name", lambda _id: "new #id1")
     assert not rename.rename_one_work(1)
     captured = capsys.readouterr()
     assert "存在しません" in captured.out
@@ -171,7 +171,7 @@ def test_rename_one_work_new_path_exists(tmp_path, monkeypatch, capsys):
     db_path = tmp_path / "db.sqlite"
     conn = setup_db(db_path)
     old_dir = tmp_path / "old"
-    new_dir = tmp_path / "new"
+    new_dir = tmp_path / "new #id1"
     old_dir.mkdir()
     new_dir.mkdir()
     conn.execute(
@@ -182,7 +182,7 @@ def test_rename_one_work_new_path_exists(tmp_path, monkeypatch, capsys):
     conn.commit()
     conn.close()
     patch_get_connection(monkeypatch, db_path)
-    monkeypatch.setattr(rename, "compose_folder_name", lambda _id: "new")
+    monkeypatch.setattr(rename, "compose_folder_name", lambda _id: "new #id1")
     assert not rename.rename_one_work(1)
     captured = capsys.readouterr()
     assert "既に存在" in captured.out
@@ -206,7 +206,7 @@ def prepare_confirmed(db_path: Path, folder: Path) -> None:
 
 def run_confirmed(monkeypatch, db_path: Path, date: datetime, tmp_path: Path):
     patch_get_connection(monkeypatch, db_path)
-    monkeypatch.setattr(rename, "compose_folder_name", lambda _id: "new")
+    monkeypatch.setattr(rename, "compose_folder_name", lambda _id: "new #id1")
     class DummyDatetime:
         @classmethod
         def now(cls):
@@ -238,7 +238,7 @@ def test_rename_all_confirmed_missing_old(tmp_path, monkeypatch):
 def test_rename_all_confirmed_new_exists(tmp_path, monkeypatch):
     db = tmp_path / "db.sqlite"
     old_dir = tmp_path / "old"
-    new_dir = tmp_path / "new"
+    new_dir = tmp_path / "new #id1"
     old_dir.mkdir()
     new_dir.mkdir()
     prepare_confirmed(db, old_dir)
@@ -253,7 +253,7 @@ def test_rename_all_confirmed_exception(tmp_path, monkeypatch):
     folder.mkdir()
     prepare_confirmed(db, folder)
     patch_get_connection(monkeypatch, db)
-    monkeypatch.setattr(rename, "compose_folder_name", lambda _id: "new")
+    monkeypatch.setattr(rename, "compose_folder_name", lambda _id: "new #id1")
     def fail(*args, **kwargs):
         raise RuntimeError("boom")
     monkeypatch.setattr(os, "rename", fail)


### PR DESCRIPTION
## Summary
- include `#id{work_id}` suffix when creating folder names
- ignore `#id{}` suffixes when parsing folder names
- update rename-related tests for new naming pattern
- avoid extra whitespace when composing folder names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872d950d3b8832ca9eff53eae979f93